### PR TITLE
Handle Detekt application via convention plugin

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,9 +26,10 @@ dependencies {
     implementation(gradleApi())
     implementation(gradleTestKit())
     implementation(libs.moshi.kotlin)
-    // We reference these plugin classes in code; keep them compileOnly so consumers don’t get them transitively
-    compileOnly(libs.gradle)                // com.android.tools.build:gradle:<agp version from catalog>
-    compileOnly(libs.detekt.gradle.plugin)  // detekt-gradle-plugin:<detekt version from catalog>
+    // We compile against AGP without bundling it; Detekt & Android JUnit5 ship for consumers
+    compileOnly(libs.gradle) // com.android.tools.build:gradle:<agp version from catalog>
+    implementation(libs.detekt.gradle.plugin) // detekt-gradle-plugin:<detekt version from catalog>
+    implementation(libs.junit5.android.plugin) // de.mannodermaus:android-junit5
     // detekt custom rules API for our provider/rules
     compileOnly(libs.detekt.api)
 
@@ -39,7 +40,7 @@ dependencies {
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.mockk)
     testImplementation(kotlin("gradle-plugin", "1.9.24"))
-    testImplementation(libs.detekt.gradle.plugin)
+    // runtime plugin deps come transitively from implementation
 
     tasks.withType<Test>().configureEach {
         useJUnitPlatform()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ moshi = "1.15.2"
 junit = "5.13.4"
 mockk = "1.14.5"
 detekt = "1.23.8"
+mannodermaus = "1.13.1.0"
 
 [plugins]
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
@@ -15,6 +16,7 @@ moshi-kotlin = { module = "com.squareup.moshi:moshi-kotlin", version.ref = "mosh
 gradle = { module = "com.android.tools.build:gradle", version.ref = "agp" }
 detekt-gradle-plugin = { module = "io.gitlab.arturbosch.detekt:detekt-gradle-plugin", version.ref = "detekt" }
 detekt-api = { module = "io.gitlab.arturbosch.detekt:detekt-api", version.ref = "detekt" }
+junit5-android-plugin = { module = "de.mannodermaus.gradle.plugins:android-junit5", version.ref = "mannodermaus" }
 junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
 junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
 junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }


### PR DESCRIPTION
## Summary
- Avoid hard compile-time dependency on Detekt
- Apply Detekt only after Android plugins and defer for JVM modules
- Bundle Detekt and Android JUnit5 plugins so convention plugin can apply them without extra setup

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68c6ae45c8788333b68d69d64ed1aed6