### PR TITLE
Filter executed unit tests before running tests audit

### DIFF
--- a/src/test/kotlin/com/supernova/testgate/audits/TestsAuditTest.kt
+++ b/src/test/kotlin/com/supernova/testgate/audits/TestsAuditTest.kt
@@ -149,10 +149,31 @@ class TestsAuditTest {
     }
 
     @Test
-    fun `missing directory throws`() {
+    fun `missing directory returns empty result`() {
         val dir = File(tmp, "missing")
         val audit = TestsAudit("app", dir, logger = null)
-        assertThrows(IllegalStateException::class.java) { audit.check { } }
+        var result: AuditResult? = null
+        audit.check { result = it }
+
+        val r = requireNotNull(result)
+        assertEquals(Status.PASS, r.status)
+        assertEquals(0, r.findingCount)
+        assertTrue(r.findings.isEmpty())
+    }
+
+    @Test
+    fun `missing xml references executed tasks`() {
+        val dir = File(tmp, "empty").apply { mkdirs() }
+        val audit = TestsAudit(
+            module = "app",
+            resultsDir = dir,
+            logger = null,
+            executedTaskNames = listOf(":app:testDebugUnitTest")
+        )
+        val ex = assertThrows(IllegalStateException::class.java) {
+            audit.check { }
+        }
+        assertTrue(ex.message!!.contains(":app:testDebugUnitTest"))
     }
 
     @Test


### PR DESCRIPTION
## Summary
- skip unit test audit runs for Gradle test tasks that did not execute during the build
- enrich TestsAudit with executed task metadata and guard missing report directories
- adjust the tests audit unit tests to cover the new defensive behavior

## Testing
- ./gradlew test

------
https://chatgpt.com/codex/tasks/task_e_68c927faeb308333834d7e853c1ee9c7